### PR TITLE
The Player can now detect the change of the 'background' color coming from props.

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -190,7 +190,7 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
   }
 
   private async createLottie() {
-    const { autoplay, direction, loop, lottieRef, renderer, speed, src } = this.props;
+    const { autoplay, direction, loop, lottieRef, renderer, speed, src, background } = this.props;
     const { instance } = this.state;
 
     if (!src || !this.container) {
@@ -261,6 +261,10 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
 
       if (direction) {
         this.setPlayerDirection(direction);
+      }
+
+      if (background) {
+        this.setState({ background });
       }
 
       this.setState({ instance: newInstance }, () => {


### PR DESCRIPTION
The 'background' prop is unused and so the Player uses only the default value (transparent).
One of the workarounds of this problem was to send the value of 'background' via 'style' prop.