### PR TITLE
Making autoplay prop optional

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -56,7 +56,7 @@ export interface IPlayerProps {
   onEvent?: (event: PlayerEvent) => any;
   onStateChange?: (state: PlayerState) => any;
   onBackgroundChange?: (color: string) => void;
-  autoplay: boolean;
+  autoplay?: boolean;
   background?: string;
   children?: React.ReactNode | React.ReactNode[];
   controls?: boolean;


### PR DESCRIPTION
Hi
I read this table but I have to write `autoplay` prop when I'm using Player component.

Prop | Description | Type | Default
-- | -- | -- | --
autoplay | Autoplay animation on load. | boolean | false

So I made `autoplay` prop **optional**.
Please check it.
Have a nice day :)
