### PR TITLE
Add loop event/bugfix complete event

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -315,7 +315,6 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
       newInstance.addEventListener('complete', () => {
         this.triggerEvent(PlayerEvent.Complete);
         this.setState({ playerState: PlayerState.Paused });
-        this.setSeeker(0);
       });
 
       // Set initial playback speed and direction

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -306,6 +306,11 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
         this.setState({ playerState: PlayerState.Error });
       });
 
+      // Handle new loop event
+      newInstance.addEventListener('loopComplete', () => {
+        this.triggerEvent(PlayerEvent.Loop);
+      });
+
       // Set state to paused if loop is off and anim has completed
       newInstance.addEventListener('complete', () => {
         this.triggerEvent(PlayerEvent.Complete);


### PR DESCRIPTION
#### Reference Issue / PR
None
#### What does this implement/fix? Explain your changes.
I've added the loop event which will get triggered when the animation loops. I also noticed that if `loop=false`, the animation would reset back to frame 0. I think it should remain on the final frame otherwise, we're technically looping it. Thus, I've removed setting the seek back to 0 on complete.  
#### Any other comments?
No