### PR TITLE
Add keepLastFrame prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,23 @@ Add the element `Player` and set the `src` prop to a URL pointing to a valid Lot
 
 ## Props
 
-| Prop                 | Description                         | Type               | Default     |
-| -------------------- | ----------------------------------- | ------------------ | ----------- |
-| `lottieRef`          | Get lottie animation object         | `function`         | `undefined` |
-| `onEvent`            | Listen for events                   | `function`         | `undefined` |
-| `onStateChange`      | Play state changes                  | `function`         | `undefined` |
-| `onBackgroundChange` | Listen for bg changes               | `function`         | `undefined` |
-| `autoplay`           | Autoplay animation on load.         | `boolean`          | `false`     |
-| `background`         | Background color.                   | `string`           | `undefined` |
-| `controls`           | Show controls.                      | `boolean`          | `false`     |
-| `direction`          | Direction of animation.             | `number`           | `1`         |
-| `hover`              | Whether to play on mouse hover.     | `boolean`          | `false`     |
-| `loop`               | Whether to loop animation.          | `boolean`          | `false`     |
-| `renderer`           | Renderer to use.                    | `"svg" | "canvas"` | `'svg'`     |
-| `speed`              | Animation speed.                    | `number`           | `1`         |
-| `style`              | The style for the container.        | `object`           | `undefined` |
-| `src` _(required)_   | Bodymovin JSON data or URL to JSON. | `object` | `string`| `undefined` |
+| Prop                 | Description                                                            | Type               | Default     |
+| -------------------- | ---------------------------------------------------------------------- | ------------------ | ----------- |
+| `lottieRef`          | Get lottie animation object                                            | `function`         | `undefined` |
+| `onEvent`            | Listen for events                                                      | `function`         | `undefined` |
+| `onStateChange`      | Play state changes                                                     | `function`         | `undefined` |
+| `onBackgroundChange` | Listen for bg changes                                                  | `function`         | `undefined` |
+| `autoplay`           | Autoplay animation on load.                                            | `boolean`          | `false`     |
+| `background`         | Background color.                                                      | `string`           | `undefined` |
+| `controls`           | Show controls.                                                         | `boolean`          | `false`     |
+| `direction`          | Direction of animation.                                                | `number`           | `1`         |
+| `hover`              | Whether to play on mouse hover.                                        | `boolean`          | `false`     |
+| `keepLastFrame`      | Stop animation on the last frame.</br>Has no effect if `loop` is true. | `boolean`          | `false`     |
+| `loop`               | Whether to loop animation.                                             | `boolean`          | `false`     |
+| `renderer`           | Renderer to use.                                                       | `"svg" | "canvas"` | `'svg'`     |
+| `speed`              | Animation speed.                                                       | `number`           | `1`         |
+| `style`              | The style for the container.                                           | `object`           | `undefined` |
+| `src` _(required)_   | Bodymovin JSON data or URL to JSON.                                    | `object` | `string`| `undefined` |
 
 ## Get Player instance
 

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -69,6 +69,7 @@ export interface IPlayerProps {
   src: object | string;
   style?: { [key: string]: string | number };
   rendererSettings?: object;
+  keepLastFrame?: boolean;
 }
 
 interface IPlayerState {
@@ -309,7 +310,10 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
       newInstance.addEventListener('complete', () => {
         this.triggerEvent(PlayerEvent.Complete);
         this.setState({ playerState: PlayerState.Paused });
-        this.setSeeker(0);
+
+        if (!this.props.keepLastFrame || this.props.loop) {
+          this.setSeeker(0);
+        }
       });
 
       // Set initial playback speed and direction


### PR DESCRIPTION
Adds `keepLastFrame` prop that allows finishing the animation on the last frame. It has no effect if `loop` is `true`

Fixes https://github.com/LottieFiles/lottie-react/issues/9