### PR TITLE
Added the option to remove wrapper tag `div`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Add the element `Player` and set the `src` prop to a URL pointing to a valid Lot
 | `speed`              | Animation speed.                                                       | `number`           | `1`         |
 | `style`              | The style for the container.                                           | `object`           | `undefined` |
 | `src` _(required)_   | Bodymovin JSON data or URL to JSON.                                    | `object` | `string`| `undefined` |
+| `withoutWrapperTag`  | Remove wrapper `div` tag                                               | `boolean`          | `false`     |
+| `className`          | Provide string as className.                                           | `string`           | `undefined` |
 
 ## Get Player instance
 

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -78,6 +78,7 @@ export interface IPlayerProps {
   rendererSettings?: object;
   keepLastFrame?: boolean;
   className?: string;
+  withoutWrapperTag?: boolean;
 }
 
 interface IPlayerState {
@@ -199,11 +200,13 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
   };
 
   public render() {
-    const { children, loop, style, onBackgroundChange, className } = this.props;
+    const { children, loop, style, onBackgroundChange, className, withoutWrapperTag } = this.props;
     const { animationData, instance, playerState, seeker, debug, background } = this.state;
+    const DefaultTag = (tagProp: React.PropsWithChildren<React.ReactNode | React.ReactNode[]>) => React.createElement("div", { className: "lf-player-container" }, tagProp.children);
+    const WrapperTag = withoutWrapperTag ? React.Fragment : DefaultTag;
 
     return (
-      <div className="lf-player-container">
+      <WrapperTag>
         <div
           id={this.props.id ? this.props.id : 'lottie'}
           ref={el => (this.container = el)}
@@ -249,7 +252,7 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
           }
           return null;
         })}
-      </div>
+      </WrapperTag>
     );
   }
 


### PR DESCRIPTION
## Description

Added the option to remove wrapper tag `div`.
Related to this issue:
https://github.com/LottieFiles/lottie-react/issues/14

## Type of change

Added a prop `withoutWrapperTag` as boolean.
Provided changes in code to cover use this prop.

No changes in package.json

## Checklist

- [ ] Check and approve
