### PR TITLE
fix: bail-out from async `createLottie` after unmount

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -298,6 +298,10 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
         animationData = await fetchResult.json();
       }
 
+      if (this.unmounted) {
+        return;
+      }
+
       // Clear previous animation, if any
       if (instance) {
         instance.destroy();


### PR DESCRIPTION
## Description

Without this we might end up with a warning in older versions of React:
> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

## Type of change

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
