### PR TITLE
Fix: `direction` property on `Player` component

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -332,6 +332,9 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
       if (speed) {
         newInstance.setSpeed(speed);
       }
+      if (direction) {
+        newInstance.setDirection(direction);
+      }
       this.setState({ animationData });
 
       // Handle new frame event


### PR DESCRIPTION
## Description

Fixes issue [#68](https://github.com/LottieFiles/lottie-react/issues/68).

## Type of change

Calls `setDirection` on a new instance of an animation with a specified `direction` as parameter.

- [x] lottie-react Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] This is something we need to do.
