### PR TITLE
fix: added new instanceloaded event

### DIFF
--- a/.changeset/few-tables-notice.md
+++ b/.changeset/few-tables-notice.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/react-lottie-player': patch
+---
+
+added instanceloaded event


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

Added a new event to fire when the internal instance of the animation has been set. This is to avoid confusion with the load event, as load fires when Lottie has fired DOMLoaded, but setting the state of the react player has not yet been set, causing confusion when the player doesn't perform as expected in the user event handler.

This PR is a fix directed towards this issue

For context:
https://stackoverflow.com/questions/75213109/why-lottieref-returns-only-null

Where the 'load' event was firing, but 'setState(instance)' had not yet completed, thus when we caught the 'load' event and tried player.play(), the method would fail as the instance was not yet set.

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] This is something we need to do.
