### PR TITLE
feat: use lottie-web light version

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -1,4 +1,5 @@
-import lottie, { AnimationItem } from 'lottie-web';
+import type { AnimationItem } from 'lottie-web';
+import lottie from "lottie-web/build/player/lottie_light.min.js";
 import * as React from 'react';
 
 import { LOTTIE_WEB_VERSION, REACT_LOTTIE_PLAYER_VERSION } from './versions';

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -1,5 +1,5 @@
 import type { AnimationItem } from 'lottie-web';
-import lottie from "lottie-web/build/player/lottie_light.min.js";
+import lottie from "lottie-web/build/player/lottie_light";
 import * as React from 'react';
 
 import { LOTTIE_WEB_VERSION, REACT_LOTTIE_PLAYER_VERSION } from './versions';


### PR DESCRIPTION
Hello,

According to this issue https://github.com/airbnb/lottie-web/issues/1184 there is a "light" version.

Maybe i'm missing smth, but seems like its working, `npm run build` output:
Before:
![CleanShot 2023-11-29 at 18 35 04@2x](https://github.com/LottieFiles/lottie-react/assets/5851280/e95e455b-48c3-46b0-a511-9d9b08b6ab15)
After:
![CleanShot 2023-11-29 at 18 35 10@2x](https://github.com/LottieFiles/lottie-react/assets/5851280/d49849a4-a275-42d0-89ee-7c4e542073eb)
