### PR TITLE
fix: fix cross-platform layout inconsistency when used with lottie-react-native

### DIFF
--- a/.changeset/giant-turtles-wave.md
+++ b/.changeset/giant-turtles-wave.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/react-lottie-player": patch
+---
+
+fix: replace lf-player-container div to fix layout inconsistency when used with lottie-react-native

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -225,7 +225,7 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
     const { animationData, instance, playerState, seeker, debug, background } = this.state;
 
     return (
-      <div className="lf-player-container">
+      <>
         {this.state.playerState === PlayerState.Error ? (
           <div className="lf-error">
             <span aria-label="error-symbol" role="img">
@@ -279,7 +279,7 @@ export class Player extends React.Component<IPlayerProps, IPlayerState> {
           }
           return null;
         })}
-      </div>
+      </>
     );
   }
 

--- a/src/Styles.css
+++ b/src/Styles.css
@@ -65,9 +65,6 @@
 .lf-progress:focus::-ms-fill-upper {
   background: #ccc;
 }
-.lf-player-container :focus {
-  outline: 0;
-}
 .lf-popover {
   position: relative;
 }


### PR DESCRIPTION
## Description

[lottie-react-native](https://github.com/lottie-react-native/lottie-react-native) supports web by leveraging this library under the hood. 

The `lf-player-container` div is a problem for universal apps because it cannot be styled via props and it's default styling is not consistent with the default React Native View's styling, which causes the web lottie components to have a different layout than their native counterparts.

On web, the default display and margin values cause the Lottie container to occupy the full width of it's container and, as a result, the lottie animation content is horizontally centered.

<img width="1728" alt="image" src="https://github.com/LottieFiles/lottie-react/assets/16565387/96d1e7f9-4b9f-42d7-b94e-965dabdfda52">

On native, the same component will only occupy the width of the lottie animation.

<img width="565" alt="image" src="https://github.com/LottieFiles/lottie-react/assets/16565387/7a4e069a-8c59-4fa0-8a06-6b4f9ddae1b0">

## Type of change

Replace the `lf-player-container` div with a react fragment.

## Checklist

- [x] Verified that the storybook test does not show any signs of regression, and that the removal of the outline style applied to `lf-player-container` does not result in an outline due to tab focus.
<img width="1728" alt="image" src="https://github.com/LottieFiles/lottie-react/assets/16565387/02acbf49-9113-4559-ac54-cb98f9e640f9">
