### PR TITLE
chore: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-## LottiePlayer React Component
+> [!IMPORTANT]
+> **This package (`@lottiefiles/react-lottie-player`) is deprecated and no longer maintained.**
+> Please use [`@lottiefiles/dotlottie-react`](https://npmjs.com/package/@lottiefiles/dotlottie-react) instead.
+>
+> - npm: https://npmjs.com/package/@lottiefiles/dotlottie-react
+> - GitHub: https://github.com/lottiefiles/dotlottie-web
+
+---
+
+## LottiePlayer React Component (Deprecated)
 
 This is a React component for the Lottie Web Player
 


### PR DESCRIPTION
## Summary

- Added a deprecation notice to the top of the README using GitHub `> [!IMPORTANT]` admonition syntax
- The notice directs users to `@lottiefiles/dotlottie-react` as the maintained successor, with links to npm and GitHub
- Appended "(Deprecated)" to the main title heading
- Added a horizontal rule (`---`) to separate the notice from the rest of the README